### PR TITLE
Add 'exclude-path-length' flag to 'init' command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -120,6 +120,11 @@ func initAction(c *cli.Context) {
 		os.Exit(1)
 	}
 
+	if c.IsSet("path-length") && c.IsSet("exclude-path-length") {
+		fmt.Fprintf(os.Stderr, "The \"path-length\" and \"exclude-path-length\" flags cannot be used together!\n")
+		os.Exit(1)
+	}
+
 	var err error
 	expires := c.String("expires")
 	if years := c.Int("years"); years != 0 {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -98,6 +98,10 @@ func NewInitCommand() cli.Command {
 				Value: 0,
 				Usage: "Maximum number of non-self-issued intermediate certificates that may follow this CA certificate in a valid certification path",
 			},
+			cli.BoolFlag{
+				Name:  "exclude-path-length",
+				Usage: "Exclude 'pathlen' from this CA certificate",
+			},
 		},
 		Action: initAction,
 	}
@@ -181,7 +185,7 @@ func initAction(c *cli.Context) {
 		}
 	}
 
-	crt, err := pkix.CreateCertificateAuthority(key, c.String("organizational-unit"), expiresTime, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), c.String("common-name"), c.StringSlice("permit-domain"), c.Int("path-length"))
+	crt, err := pkix.CreateCertificateAuthority(key, c.String("organizational-unit"), expiresTime, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), c.String("common-name"), c.StringSlice("permit-domain"), c.Int("path-length"), c.Bool("exclude-path-length"))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Create certificate error:", err)
 		os.Exit(1)

--- a/cmd/revoke_test.go
+++ b/cmd/revoke_test.go
@@ -75,7 +75,7 @@ func setupCA(t *testing.T, dt depot.Depot) {
 	}
 
 	// create certificate authority
-	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), "", "", "", "", caName, nil, 0)
+	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), "", "", "", "", caName, nil, 0, false)
 	if err != nil {
 		t.Fatalf("could not create authority cert: %v", err)
 	}

--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -59,7 +59,7 @@ func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time
 		authTemplate.PermittedDNSDomains = permitDomains
 	}
 
-	if excludePathlen == false {
+	if !excludePathlen {
 		if pathlen > 0 {
 			authTemplate.MaxPathLen = pathlen
 			authTemplate.MaxPathLenZero = false

--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -26,7 +26,7 @@ import (
 
 // CreateCertificateAuthority creates Certificate Authority using existing key.
 // CertificateAuthorityInfo returned is the extra infomation required by Certificate Authority.
-func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time.Time, organization string, country string, province string, locality string, commonName string, permitDomains []string, pathlen int) (*Certificate, error) {
+func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time.Time, organization string, country string, province string, locality string, commonName string, permitDomains []string, pathlen int, excludePathlen bool) (*Certificate, error) {
 	authTemplate := newAuthTemplate()
 
 	subjectKeyID, err := GenerateSubjectKeyID(key.Public)
@@ -59,8 +59,12 @@ func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time
 		authTemplate.PermittedDNSDomains = permitDomains
 	}
 
-	if pathlen > 0 {
-		authTemplate.MaxPathLen = pathlen
+	if excludePathlen == false {
+		if pathlen > 0 {
+			authTemplate.MaxPathLen = pathlen
+			authTemplate.MaxPathLenZero = false
+		}
+	} else {
 		authTemplate.MaxPathLenZero = false
 	}
 
@@ -127,7 +131,7 @@ func newAuthTemplate() x509.Certificate {
 	return x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		// NotBefore is set to be 10min earlier to fix gap on time difference in cluster
-		NotBefore: time.Now().Add(-10*time.Minute).UTC(),
+		NotBefore: time.Now().Add(-10 * time.Minute).UTC(),
 		NotAfter:  time.Time{},
 		// Used for certificate signing only
 		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,

--- a/pkix/cert_auth_test.go
+++ b/pkix/cert_auth_test.go
@@ -28,7 +28,7 @@ func TestCreateCertificateAuthority(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", []string{".example.com"}, 0)
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", []string{".example.com"}, 0, false)
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}

--- a/pkix/crl_test.go
+++ b/pkix/crl_test.go
@@ -49,7 +49,7 @@ func TestCreateCertificateRevocationList(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", nil, 0)
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", nil, 0, false)
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}


### PR DESCRIPTION
- Add 'exclude-path-length' flag to 'init' command
- Ensure that 'path-length' and 'exclude-path-length' cannot be used together
